### PR TITLE
TicketStock 재고 차감 도메인 로직 및 단위 테스트 구현 #6

### DIFF
--- a/src/main/java/com/ticket_service/ticket/entity/TicketStock.java
+++ b/src/main/java/com/ticket_service/ticket/entity/TicketStock.java
@@ -1,8 +1,14 @@
 package com.ticket_service.ticket.entity;
 
 import com.ticket_service.concert.entity.Concert;
+import com.ticket_service.ticket.exception.InsufficientTicketStockException;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class TicketStock {
     @Id
@@ -14,5 +20,36 @@ public class TicketStock {
 
     private int totalQuantity;
 
+    @Getter
     private int remainingQuantity;
+
+    @Builder
+    public TicketStock(Long id, Concert concert, int totalQuantity, int remainingQuantity) {
+        if (totalQuantity < 0) {
+            throw new IllegalArgumentException("totalQuantity must be >= 0");
+        }
+        if (remainingQuantity < 0) {
+            throw new IllegalArgumentException("remainingQuantity must be >= 0");
+        }
+        if (remainingQuantity > totalQuantity) {
+            throw new IllegalArgumentException("remainingQuantity cannot exceed totalQuantity");
+        }
+
+        this.id = id;
+        this.concert = concert;
+        this.totalQuantity = totalQuantity;
+        this.remainingQuantity = remainingQuantity;
+    }
+
+    public void decreaseQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("quantity must be positive");
+        }
+
+        if (remainingQuantity < quantity) {
+            throw new InsufficientTicketStockException(remainingQuantity, quantity);
+        }
+
+        remainingQuantity -= quantity;
+    }
 }

--- a/src/main/java/com/ticket_service/ticket/exception/InsufficientTicketStockException.java
+++ b/src/main/java/com/ticket_service/ticket/exception/InsufficientTicketStockException.java
@@ -1,0 +1,21 @@
+package com.ticket_service.ticket.exception;
+
+public class InsufficientTicketStockException extends RuntimeException {
+
+    private final int remainingQuantity;
+    private final int requestQuantity;
+
+    public InsufficientTicketStockException(int remainingQuantity, int requestQuantity) {
+        this.remainingQuantity = remainingQuantity;
+        this.requestQuantity = requestQuantity;
+    }
+
+    public int getRemainingQuantity() {
+        return remainingQuantity;
+    }
+
+    public int getRequestQuantity() {
+        return requestQuantity;
+    }
+}
+

--- a/src/test/java/com/ticket_service/ticket/entity/TicketStockTest.java
+++ b/src/test/java/com/ticket_service/ticket/entity/TicketStockTest.java
@@ -1,0 +1,63 @@
+package com.ticket_service.ticket.entity;
+
+import com.ticket_service.ticket.exception.InsufficientTicketStockException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TicketStockTest {
+
+    @Test
+    @DisplayName("재고가 충분하면 요청 수량만큼 차감된다")
+    void decreaseQuantity_success() {
+        // given
+        TicketStock ticketStock = TicketStock.builder()
+                .totalQuantity(100)
+                .remainingQuantity(100)
+                .build();
+
+        // when
+        ticketStock.decreaseQuantity(10);
+
+        // then
+        assertThat(ticketStock.getRemainingQuantity()).isEqualTo(90);
+    }
+
+    @Test
+    @DisplayName("차감 요청 수량이 0 이하이면 예외가 발생한다")
+    void decreaseQuantity_quantityLessThanOrEqualZero() {
+        // given
+        TicketStock ticketStock = TicketStock.builder()
+                .totalQuantity(100)
+                .remainingQuantity(100)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> ticketStock.decreaseQuantity(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("quantity must be positive");
+    }
+
+    @Test
+    @DisplayName("재고보다 많은 수량을 요청하면 재고 부족 예외가 발생한다")
+    void decreaseQuantity_insufficientStock() {
+        // given
+        TicketStock ticketStock = TicketStock.builder()
+                .totalQuantity(10)
+                .remainingQuantity(5)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> ticketStock.decreaseQuantity(6))
+                .isInstanceOf(InsufficientTicketStockException.class)
+                .satisfies(ex -> {
+                    InsufficientTicketStockException e =
+                            (InsufficientTicketStockException) ex;
+
+                    assertThat(e.getRemainingQuantity()).isEqualTo(5);
+                    assertThat(e.getRequestQuantity()).isEqualTo(6);
+                });
+    }
+}


### PR DESCRIPTION
TicketStock 엔티티에 재고 차감을 구현하고, 단위 테스트를 추가했습니다.

- TicketStock 엔티티에 재고 차감 메서드 추가
  - 요청 수량 검증
  - 재고 부족 시 예외 발생
- 재고 부족 상황을 표현하는 InsufficientTicketStockException 정의
- 단위 테스트로 메서드 검증