### PR TITLE
TicketStock 재고 차감 로직 동시성 처리 #9

### DIFF
--- a/src/main/java/com/ticket_service/ticket/entity/TicketStock.java
+++ b/src/main/java/com/ticket_service/ticket/entity/TicketStock.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class TicketStock {
@@ -20,7 +21,6 @@ public class TicketStock {
 
     private int totalQuantity;
 
-    @Getter
     private int remainingQuantity;
 
     @Builder

--- a/src/main/java/com/ticket_service/ticket/repository/TicketStockRepository.java
+++ b/src/main/java/com/ticket_service/ticket/repository/TicketStockRepository.java
@@ -1,0 +1,7 @@
+package com.ticket_service.ticket.repository;
+
+import com.ticket_service.ticket.entity.TicketStock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketStockRepository extends JpaRepository<TicketStock, Long> {
+}

--- a/src/main/java/com/ticket_service/ticket/service/TicketStockService.java
+++ b/src/main/java/com/ticket_service/ticket/service/TicketStockService.java
@@ -1,0 +1,21 @@
+package com.ticket_service.ticket.service;
+
+import com.ticket_service.ticket.entity.TicketStock;
+import com.ticket_service.ticket.repository.TicketStockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TicketStockService {
+    private final TicketStockRepository ticketStockRepository;
+
+    @Transactional
+    public synchronized void decrease(Long ticketStockId, int requestQuantity) {
+        TicketStock ticketStock = ticketStockRepository.findById(ticketStockId)
+                .orElseThrow(() -> new IllegalArgumentException("TicketStock not found"));
+
+        ticketStock.decreaseQuantity(requestQuantity);
+    }
+}

--- a/src/test/java/com/ticket_service/ticket/service/TicketStockServiceTest.java
+++ b/src/test/java/com/ticket_service/ticket/service/TicketStockServiceTest.java
@@ -1,0 +1,66 @@
+package com.ticket_service.ticket.service;
+
+import com.ticket_service.ticket.entity.TicketStock;
+import com.ticket_service.ticket.repository.TicketStockRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TicketStockServiceTest {
+
+    @Autowired
+    private TicketStockService ticketStockService;
+
+    @Autowired
+    private TicketStockRepository ticketStockRepository;
+
+    @DisplayName("synchronized 메서드는 다중 스레드 환경에서 티켓 재고를 안전하게 차감한다")
+    @Test
+    void synchronized_decrease_should_be_thread_safe() throws Exception {
+        // given
+        int initialQuantity = 1000;
+        int threadCount = 1000;
+        int requestQuantityPerThread = 1;
+
+        TicketStock ticketStock = ticketStockRepository.save(
+                TicketStock.builder()
+                        .totalQuantity(initialQuantity)
+                        .remainingQuantity(initialQuantity)
+                        .build()
+        );
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    ticketStockService.decrease(ticketStock.getId(), requestQuantityPerThread);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드 종료 대기
+        executorService.shutdown();
+
+        // then
+        TicketStock result = ticketStockRepository.findById(ticketStock.getId())
+                .orElseThrow();
+
+        assertThat(result.getRemainingQuantity()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
티켓 재고 차감 로직에서 애플리케이션 레벨 synchronized 락으로
동시성 제어를 시도했으나, 멀티스레드 환경에서 재고 정합성이 보장되지 않는 문제가 확인됩니다.

### 원인 분석
- 티켓 재고 차감(synchronized) 메서드 실행 후 객체 인스턴스 락 반납. (아직 DB는 commit 되기 전)
- 트랜잭션 commit 전에 다른 스레드가 티켓 재고 차감을 실행하여 commit 되지 않은 데이터를 읽음.
- 여러 스레드가 같은 값을 기준으로 update 쿼리를 실행함.
- aop 기반 트랜잭션을 사용하고 commit이 synchronized 밖에서 일어나기 때문에 이런 문제가 발생하는 것으로 보입니다.

### 후속 작업
- DB 락 적용 예정
- 동일 테스트에서 정합성 보장 여부 재검증