### PR TITLE
대기열 API 성능 테스트 #67

### DIFF
--- a/performance/k6/ticket-stock-direct.js
+++ b/performance/k6/ticket-stock-direct.js
@@ -3,7 +3,7 @@ import { check, sleep } from 'k6';
 
 export const options = {
     scenarios: {
-        ticket_stock_test: {
+        ticket_stock_direct_test: {
             executor: 'constant-vus',
             vus: 100,            // 동시 사용자 수
             duration: '10s',     // 테스트 지속 시간
@@ -15,7 +15,7 @@ const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const TICKET_STOCK_ID = __ENV.TICKET_STOCK_ID || 1;
 
 export default function () {
-    const url = `${BASE_URL}/ticket-stocks/${TICKET_STOCK_ID}`;
+    const url = `${BASE_URL}/ticket-stocks/${TICKET_STOCK_ID}/direct`;
 
     const payload = JSON.stringify({
         requestQuantity: 1,

--- a/performance/k6/ticket-stock-queue.js
+++ b/performance/k6/ticket-stock-queue.js
@@ -1,0 +1,68 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+    scenarios: {
+        ticket_stock_queue_test: {
+            executor: 'constant-vus',
+            vus: 100,            // 동시 사용자 수
+            duration: '10s',     // 테스트 지속 시간
+        },
+    },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const TICKET_STOCK_ID = __ENV.TICKET_STOCK_ID || 1;
+
+export default function () {
+    const userId = `user-${__VU}-${__ITER}`;
+
+    // 1. 대기열 등록
+    const queueUrl = `${BASE_URL}/queues/${TICKET_STOCK_ID}/enter`;
+    const queuePayload = JSON.stringify({ userId });
+    const params = {
+        headers: { 'Content-Type': 'application/json' },
+    };
+
+    const queueRes = http.post(queueUrl, queuePayload, params);
+    check(queueRes, {
+        'queue registration success': (r) => r.status === 200,
+    });
+
+    if (queueRes.status !== 200) {
+        return;
+    }
+
+    const queueData = JSON.parse(queueRes.body).data;
+
+    // 2. 입장 가능할 때까지 폴링 (최대 5회)
+    let canEnter = queueData.canEnter;
+    let attempts = 0;
+    const maxAttempts = 5;
+
+    while (!canEnter && attempts < maxAttempts) {
+        sleep(0.5);
+        const statusUrl = `${BASE_URL}/queues/${TICKET_STOCK_ID}/status?userId=${userId}`;
+        const statusRes = http.get(statusUrl, params);
+
+        if (statusRes.status === 200) {
+            const statusData = JSON.parse(statusRes.body).data;
+            canEnter = statusData.canEnter;
+        }
+        attempts++;
+    }
+
+    // 3. 입장 가능하면 티켓 구매
+    if (canEnter) {
+        const purchaseUrl = `${BASE_URL}/ticket-stocks/${TICKET_STOCK_ID}`;
+        const purchasePayload = JSON.stringify({
+            userId,
+            requestQuantity: 1,
+        });
+
+        const purchaseRes = http.post(purchaseUrl, purchasePayload, params);
+        check(purchaseRes, {
+            'purchase success': (r) => r.status === 200,
+        });
+    }
+}

--- a/src/main/java/com/ticket_service/ticket/controller/TicketStockDirectController.java
+++ b/src/main/java/com/ticket_service/ticket/controller/TicketStockDirectController.java
@@ -1,0 +1,27 @@
+package com.ticket_service.ticket.controller;
+
+import com.ticket_service.common.dto.ApiResponse;
+import com.ticket_service.ticket.controller.dto.DecreaseRequest;
+import com.ticket_service.ticket.service.TicketStockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 대기열 검증 없이 직접 티켓 재고를 차감하는 컨트롤러
+ * 성능 테스트 및 개발 환경에서 락 전략별 성능 비교를 위해 사용
+ */
+@RestController
+@RequiredArgsConstructor
+public class TicketStockDirectController {
+
+    private final TicketStockService ticketStockService;
+
+    @PostMapping("/ticket-stocks/{id}/direct")
+    public ApiResponse<String> decreaseDirect(@PathVariable Long id, @RequestBody DecreaseRequest request) {
+        ticketStockService.decrease(id, request.getRequestQuantity());
+        return ApiResponse.ok("success");
+    }
+}

--- a/src/main/resources/application-performance-test.yml
+++ b/src/main/resources/application-performance-test.yml
@@ -16,16 +16,23 @@ spring:
     init:
       mode: always
       data-locations: classpath:sql/performance-data.sql
+
 redis:
-  url: ${REDIS_URL}
-  timeout: 3
+  host: ${REDIS_HOST:localhost}
+  port: ${REDIS_PORT:6379}
+  timeout: 3000
   lock:
     wait-time: 5
     lease-time: 3
 
+queue:
+  max-processing-count: 100
+  entry-timeout-seconds: 300
+  waiting-timeout-seconds: 1800
+
 ticket:
   lock:
-    strategy: pessimistic
+    strategy: distributed
 
 logging:
   level:


### PR DESCRIPTION
### 1. 대기열이 없는 API 엔드포인트 추가
`TicketStockDirectController.java`
- **엔드포인트**: `POST /ticket-stocks/{id}/direct`
- **목적**: 대기열 없이 락 전략별 순수 성능 측정

### 2. k6 테스트 스크립트 추가
#### `ticket-stock-direct.js`
- 대기열 없는 API를 호출하는 테스트 스크립트 (기존에 있던 것)
- 100 VUs, 10초 동안 실행
- 락 전략(pessimistic/optimistic/distributed) 성능 비교용
#### `ticket-stock-queue.js`
- 대기열 기반 전체 플로우 테스트
- 대기열 등록 → 폴링 → 구매 시나리오
- 프로덕션 환경 시뮬레이션용

### 3. 설정 파일 추가
**`application-performance-test.yml`**
- Redis 설정
- Queue 설정

### 4. 문서화
**`performance/k6/README.md`**
- 두 가지 테스트 시나리오 설명 추가
- API 엔드포인트 사용법 문서화
- 테스트 실행 방법 및 사용 사례 명시