### PR TITLE
분산 환경에서 SSE 이벤트 전달 실패 - Redis Pub/Sub 도입 필요 #106

### DIFF
--- a/src/main/java/com/ticket_service/common/redis/RedisPubSubConfig.java
+++ b/src/main/java/com/ticket_service/common/redis/RedisPubSubConfig.java
@@ -1,0 +1,17 @@
+package com.ticket_service.common.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class RedisPubSubConfig {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory queueRedisConnectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(queueRedisConnectionFactory);
+        return container;
+    }
+}

--- a/src/main/java/com/ticket_service/queue/service/QueueEventPublisher.java
+++ b/src/main/java/com/ticket_service/queue/service/QueueEventPublisher.java
@@ -1,0 +1,31 @@
+package com.ticket_service.queue.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticket_service.queue.service.dto.QueueEnterMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueEventPublisher {
+
+    public static final String QUEUE_ENTER_CHANNEL = "queue:enter";
+
+    private final RedisTemplate<String, String> queueRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void publishEnterEvent(Long concertId, String userId) {
+        try {
+            QueueEnterMessage message = QueueEnterMessage.of(concertId, userId);
+            String json = objectMapper.writeValueAsString(message);
+            queueRedisTemplate.convertAndSend(QUEUE_ENTER_CHANNEL, json);
+            log.info("[PUB] 입장 이벤트 발행: concertId={}, userId={}", concertId, userId);
+        } catch (JsonProcessingException e) {
+            log.error("입장 이벤트 직렬화 실패: concertId={}, userId={}", concertId, userId, e);
+        }
+    }
+}

--- a/src/main/java/com/ticket_service/queue/service/QueueEventSubscriber.java
+++ b/src/main/java/com/ticket_service/queue/service/QueueEventSubscriber.java
@@ -1,0 +1,57 @@
+package com.ticket_service.queue.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticket_service.queue.service.dto.QueueEnterEvent;
+import com.ticket_service.queue.service.dto.QueueEnterMessage;
+import com.ticket_service.queue.service.dto.QueueEventType;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueEventSubscriber implements MessageListener {
+
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final SseEmitterService sseEmitterService;
+    private final ObjectMapper objectMapper;
+
+    @PostConstruct
+    public void subscribe() {
+        redisMessageListenerContainer.addMessageListener(
+                this,
+                new ChannelTopic(QueueEventPublisher.QUEUE_ENTER_CHANNEL)
+        );
+        log.info("Redis Pub/Sub 구독 시작: channel={}", QueueEventPublisher.QUEUE_ENTER_CHANNEL);
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String json = new String(message.getBody());
+            QueueEnterMessage enterMessage = objectMapper.readValue(json, QueueEnterMessage.class);
+
+            Long concertId = enterMessage.getConcertId();
+            String userId = enterMessage.getUserId();
+
+            boolean sent = sseEmitterService.sendEventAndComplete(
+                    concertId,
+                    userId,
+                    QueueEventType.ENTER,
+                    QueueEnterEvent.processing()
+            );
+
+            if (sent) {
+                log.info("[SUB] 입장 이벤트 전송 성공: concertId={}, userId={}", concertId, userId);
+            }
+        } catch (Exception e) {
+            log.error("입장 이벤트 처리 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/ticket_service/queue/service/QueueOrchestrationService.java
+++ b/src/main/java/com/ticket_service/queue/service/QueueOrchestrationService.java
@@ -1,6 +1,5 @@
 package com.ticket_service.queue.service;
 
-import com.ticket_service.queue.service.dto.QueueEnterEvent;
 import com.ticket_service.queue.service.dto.QueueEventType;
 import com.ticket_service.queue.service.dto.QueuePositionEvent;
 import lombok.RequiredArgsConstructor;
@@ -15,14 +14,19 @@ public class QueueOrchestrationService {
 
     private final QueueService queueService;
     private final SseEmitterService sseEmitterService;
+    private final QueueEventPublisher queueEventPublisher;
 
     /**
      * 대기열 등록 + SSE 구독
      * 등록 후 대기 순번 또는 즉시 입장 이벤트를 전송한다.
+     *
+     * 중요: emitter를 먼저 생성한 후 대기열에 추가해야 함.
+     * 그렇지 않으면 다른 스레드에서 enterNextAndNotify 호출 시
+     * emitter가 없어 enter 이벤트를 놓칠 수 있음.
      */
     public SseEmitter registerAndSubscribe(Long concertId, String userId) {
-        Long position = queueService.enterWaitingQueue(concertId, userId);
         SseEmitter emitter = sseEmitterService.createEmitter(concertId, userId);
+        Long position = queueService.enterWaitingQueue(concertId, userId);
 
         if (queueService.hasProcessingCapacity(concertId)) {
             enterNextAndNotify(concertId);
@@ -57,14 +61,13 @@ public class QueueOrchestrationService {
     }
 
     /**
-     * 다음 대기자 1명을 입장시키고 입장 완료 SSE 이벤트를 전송한다.
-     * 순번 업데이트는 QueuePositionBatchScheduler에서 주기적으로 처리한다.
+     * 다음 대기자 1명을 입장시키고 Redis Pub/Sub로 입장 이벤트를 발행한다.
+     * 모든 앱 서버가 이벤트를 수신하고, 해당 유저가 연결된 서버에서 SSE를 전송한다.
      */
     private void enterNextAndNotify(Long concertId) {
         String enteredUserId = queueService.permitOneProcessing(concertId);
         if (enteredUserId != null) {
-            sseEmitterService.sendEvent(concertId, enteredUserId, QueueEventType.ENTER, QueueEnterEvent.processing());
-            sseEmitterService.completeEmitter(concertId, enteredUserId);
+            queueEventPublisher.publishEnterEvent(concertId, enteredUserId);
         }
     }
 }

--- a/src/main/java/com/ticket_service/queue/service/SseEmitterService.java
+++ b/src/main/java/com/ticket_service/queue/service/SseEmitterService.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -53,12 +54,38 @@ public class SseEmitterService {
         });
     }
 
+    /**
+     * 이벤트 전송 후 emitter를 완료 처리한다. (원자적 연산)
+     * Pub/Sub에서 enter 이벤트 수신 시 사용한다.
+     *
+     * @return emitter가 존재하고 전송 성공 시 true
+     */
+    public boolean sendEventAndComplete(Long concertId, String userId, QueueEventType eventType, Object data) {
+        String key = buildKey(concertId, userId);
+        AtomicBoolean sent = new AtomicBoolean(false);
+
+        emitters.computeIfPresent(key, (k, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name(eventType.getValue())
+                        .data(data));
+                sent.set(true);
+                emitter.complete();
+            } catch (IOException e) {
+                log.warn("SSE 이벤트 전송 실패: concertId={}, userId={}", concertId, userId, e);
+            }
+            return null;
+        });
+
+        return sent.get();
+    }
+
     public void completeEmitter(Long concertId, String userId) {
         String key = buildKey(concertId, userId);
-        SseEmitter emitter = emitters.get(key);
-        if (emitter != null) {
+        emitters.computeIfPresent(key, (k, emitter) -> {
             emitter.complete();
-        }
+            return null;
+        });
     }
 
     private String buildKey(Long concertId, String userId) {
@@ -78,10 +105,7 @@ public class SseEmitterService {
     }
 
     private void registerCallbacks(SseEmitter emitter, String key, Long concertId, String userId) {
-        emitter.onCompletion(() -> {
-            emitters.remove(key);
-            log.debug("SSE 연결 정상 종료: key={}", key);
-        });
+        emitter.onCompletion(() -> emitters.remove(key, emitter));
 
         emitter.onTimeout(() -> {
             emitter.complete();

--- a/src/main/java/com/ticket_service/queue/service/dto/QueueEnterMessage.java
+++ b/src/main/java/com/ticket_service/queue/service/dto/QueueEnterMessage.java
@@ -1,0 +1,18 @@
+package com.ticket_service.queue.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QueueEnterMessage {
+
+    private Long concertId;
+    private String userId;
+
+    public static QueueEnterMessage of(Long concertId, String userId) {
+        return new QueueEnterMessage(concertId, userId);
+    }
+}


### PR DESCRIPTION
## Summary
- 분산 환경에서 SSE 입장 이벤트가 전달되지 않는 문제 해결
- 클라이언트의 SSE 연결 서버와 이벤트 발행 서버가 다를 때 발생
- Redis Pub/Sub을 통해 모든 앱 서버에 이벤트 브로드캐스트

## 문제 상황
클라이언트가 app-1과 SSE 연결을 맺은 상태에서, 다른 사용자의 구매 완료가 app-2에서 처리되면:
- app-2에서 다음 대기자 입장 처리 및 enter 이벤트 발행 시도
- app-2에는 해당 클라이언트의 emitter가 없어 이벤트 전달 실패
- 클라이언트는 입장 이벤트를 받지 못하고 무한 대기

## 해결 방법
Redis Pub/Sub 도입:
- 입장 이벤트 발생 시 Redis 채널에 publish
- 모든 앱 서버가 subscribe하여 메시지 수신

