### PR TITLE
SSE 비동기 전송을 위한 스레드풀 인프라 구성 #110

### DIFF
--- a/docker/docker-compose-multi-node-local.yml
+++ b/docker/docker-compose-multi-node-local.yml
@@ -109,6 +109,11 @@ services:
       - "3000:3000"
     volumes:
       - ticket-service-multinode-grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
     depends_on:
       - prometheus
 

--- a/docker/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docker/monitoring/grafana/provisioning/dashboards/ticket-queue-dashboard.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/ticket-queue-dashboard.json
@@ -1,0 +1,1904 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Server Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
+          "legendFormat": "{{instance}} - {{id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Heap Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "system_cpu_usage",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "System CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(http_server_requests_seconds_count[1m])",
+          "legendFormat": "{{instance}} - {{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Queue Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "queue_waiting_size",
+          "legendFormat": "Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Waiting Queue Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "queue_processing_size",
+          "legendFormat": "Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Processing Set Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(sse_connections_active)",
+          "legendFormat": "Active Connections",
+          "refId": "A"
+        }
+      ],
+      "title": "SSE Active Connections",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Processing Performance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(queue_enter_total[1m])) by (concertId)",
+          "legendFormat": "Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Enter Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(queue_processing_entered_total[1m])) by (concertId)",
+          "legendFormat": "Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Processing Enter Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(ticket_purchase_success_total[1m]))",
+          "legendFormat": "Success",
+          "refId": "A"
+        }
+      ],
+      "title": "Purchase Success Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Failure Analysis",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(queue_enter_rejected_total[1m])) by (reason)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Rejection Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(ticket_purchase_failed_total[1m])) by (reason)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Purchase Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Waiting Time",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 37
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(queue_waiting_time_seconds_sum[1m]) / rate(queue_waiting_time_seconds_count[1m])",
+          "legendFormat": "Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Waiting Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 37
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(queue_waiting_time_seconds_bucket[1m])) by (le, concertId))",
+          "legendFormat": "P95 Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Waiting Time P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 37
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(queue_waiting_time_seconds_bucket[1m])) by (le, concertId))",
+          "legendFormat": "P99 Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Waiting Time P99",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Stock Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "green",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 46
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "ticket_stock_remaining",
+          "legendFormat": "Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Remaining Stock",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 46
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "ticket_stock_remaining",
+          "legendFormat": "Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Remaining Stock Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 46
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(ticket_stock_sold_total[1m])) by (concertId)",
+          "legendFormat": "Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ticket Sold Rate (Throughput)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 46
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(ticket_sold_per_purchase_sum[1m]) / rate(ticket_sold_per_purchase_count[1m])",
+          "legendFormat": "Avg Qty - Concert {{concertId}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Tickets Per Purchase",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Purchase Duration",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 55
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(ticket_purchase_duration_seconds_sum[1m]) / rate(ticket_purchase_duration_seconds_count[1m])",
+          "legendFormat": "Avg Duration",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Purchase Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 55
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(ticket_purchase_duration_seconds_bucket[1m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "A"
+        }
+      ],
+      "title": "Purchase Duration P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 55
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(ticket_purchase_duration_seconds_bucket[1m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "A"
+        }
+      ],
+      "title": "Purchase Duration P99",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["ticket", "queue", "monitoring"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Ticket Queue Dashboard",
+  "uid": "ticket-queue-dashboard",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/docker/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docker/monitoring/prometheus/prometheus.yml
+++ b/docker/monitoring/prometheus/prometheus.yml
@@ -6,4 +6,7 @@ scrape_configs:
     metrics_path: "/actuator/prometheus"
     static_configs:
       - targets:
-          - host.docker.internal:8080
+          - app-1:8080
+          - app-2:8080
+        labels:
+          env: "local"

--- a/src/main/java/com/ticket_service/common/config/AsyncConfig.java
+++ b/src/main/java/com/ticket_service/common/config/AsyncConfig.java
@@ -1,0 +1,36 @@
+package com.ticket_service.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Value("${sse.thread-pool.core-size:10}")
+    private int corePoolSize;
+
+    @Value("${sse.thread-pool.max-size:50}")
+    private int maxPoolSize;
+
+    @Value("${sse.thread-pool.queue-capacity:100}")
+    private int queueCapacity;
+
+    @Bean(name = "sseTaskExecutor")
+    public Executor sseTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("sse-");
+        executor.setWaitForTasksToCompleteOnShutdown(true); // 종료 시 큐에 남은 작업을 완료할 때까지 대기
+        executor.setAwaitTerminationSeconds(30); // 최대 30초간 대기 후 강제 종료
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/ticket_service/common/metrics/QueueGaugeRegistry.java
+++ b/src/main/java/com/ticket_service/common/metrics/QueueGaugeRegistry.java
@@ -1,0 +1,125 @@
+package com.ticket_service.common.metrics;
+
+import com.ticket_service.common.redis.RedissonLockTemplate;
+import com.ticket_service.queue.service.ProcessingSet;
+import com.ticket_service.queue.service.SseEmitterService;
+import com.ticket_service.queue.service.WaitingQueue;
+import com.ticket_service.ticket.entity.TicketStock;
+import com.ticket_service.ticket.repository.TicketStockRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueGaugeRegistry {
+
+    private static final String GAUGE_LOCK_KEY = "metrics:gauge:lock";
+
+    private final MeterRegistry meterRegistry;
+    private final WaitingQueue waitingQueue;
+    private final ProcessingSet processingSet;
+    private final SseEmitterService sseEmitterService;
+    private final RedissonLockTemplate redissonLockTemplate;
+    private final TicketStockRepository ticketStockRepository;
+
+    private final ConcurrentHashMap<Long, AtomicLong> waitingGaugeValues = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, AtomicLong> processingGaugeValues = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, AtomicLong> stockRemainingGaugeValues = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, AtomicLong> stockTotalGaugeValues = new ConcurrentHashMap<>();
+    private final Set<Long> knownConcertIds = ConcurrentHashMap.newKeySet();
+    private final AtomicLong sseConnectionsGauge = new AtomicLong(0);
+
+    private volatile boolean sseGaugeRegistered = false;
+
+    @Scheduled(fixedRate = 5000)
+    public void updateQueueGauges() {
+        updateRedisGaugesWithLock();
+        updateSseConnectionsGauge();
+    }
+
+    private void updateRedisGaugesWithLock() {
+        redissonLockTemplate.tryExecuteWithLock(GAUGE_LOCK_KEY, () -> {
+            Set<Long> activeConcertIds = sseEmitterService.getActiveConcertIds();
+            knownConcertIds.addAll(activeConcertIds);
+
+            for (Long concertId : knownConcertIds) {
+                updateWaitingGauge(concertId);
+                updateProcessingGauge(concertId);
+                updateStockGauges(concertId);
+            }
+        });
+    }
+
+    private void updateWaitingGauge(Long concertId) {
+        AtomicLong gaugeValue = waitingGaugeValues.computeIfAbsent(concertId, id -> {
+            AtomicLong value = new AtomicLong(0);
+            Gauge.builder("queue.waiting.size", value, AtomicLong::get)
+                    .tag("concertId", String.valueOf(id))
+                    .description("Current waiting queue size")
+                    .register(meterRegistry);
+            return value;
+        });
+        gaugeValue.set(waitingQueue.size(concertId));
+    }
+
+    private void updateProcessingGauge(Long concertId) {
+        AtomicLong gaugeValue = processingGaugeValues.computeIfAbsent(concertId, id -> {
+            AtomicLong value = new AtomicLong(0);
+            Gauge.builder("queue.processing.size", value, AtomicLong::get)
+                    .tag("concertId", String.valueOf(id))
+                    .description("Current processing set size")
+                    .register(meterRegistry);
+            return value;
+        });
+        gaugeValue.set(processingSet.size(concertId));
+    }
+
+    private void updateSseConnectionsGauge() {
+        if (!sseGaugeRegistered) {
+            Gauge.builder("sse.connections.active", sseConnectionsGauge, AtomicLong::get)
+                    .description("Active SSE connections")
+                    .register(meterRegistry);
+            sseGaugeRegistered = true;
+        }
+        sseConnectionsGauge.set(sseEmitterService.getActiveConnectionCount());
+    }
+
+    private void updateStockGauges(Long concertId) {
+        Optional<TicketStock> stockOpt = ticketStockRepository.findByConcertId(concertId);
+        if (stockOpt.isEmpty()) {
+            return;
+        }
+
+        TicketStock stock = stockOpt.get();
+
+        AtomicLong remainingGauge = stockRemainingGaugeValues.computeIfAbsent(concertId, id -> {
+            AtomicLong value = new AtomicLong(0);
+            Gauge.builder("ticket.stock.remaining", value, AtomicLong::get)
+                    .tag("concertId", String.valueOf(id))
+                    .description("Remaining ticket stock")
+                    .register(meterRegistry);
+            return value;
+        });
+        remainingGauge.set(stock.getRemainingQuantity());
+
+        AtomicLong totalGauge = stockTotalGaugeValues.computeIfAbsent(concertId, id -> {
+            AtomicLong value = new AtomicLong(0);
+            Gauge.builder("ticket.stock.total", value, AtomicLong::get)
+                    .tag("concertId", String.valueOf(id))
+                    .description("Total ticket stock")
+                    .register(meterRegistry);
+            return value;
+        });
+        totalGauge.set(stock.getTotalQuantity());
+    }
+}

--- a/src/main/java/com/ticket_service/common/metrics/QueueMetrics.java
+++ b/src/main/java/com/ticket_service/common/metrics/QueueMetrics.java
@@ -1,0 +1,157 @@
+package com.ticket_service.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class QueueMetrics {
+
+    private final MeterRegistry meterRegistry;
+    private final ConcurrentHashMap<String, Counter> enterCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Counter> rejectedCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Counter> processingEnteredCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Timer> waitingTimers = new ConcurrentHashMap<>();
+
+    // Counters for ticket purchase
+    private final Counter purchaseSuccessCounter;
+    private final Counter purchaseFailedInsufficientStockCounter;
+    private final Counter purchaseFailedAccessDeniedCounter;
+    private final Timer purchaseDurationTimer;
+
+    // Stock metrics
+    private final ConcurrentHashMap<String, Counter> stockSoldCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, DistributionSummary> soldQuantitySummaries = new ConcurrentHashMap<>();
+
+    public QueueMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+
+        this.purchaseSuccessCounter = Counter.builder("ticket.purchase.success")
+                .description("Total successful ticket purchases")
+                .register(meterRegistry);
+
+        this.purchaseFailedInsufficientStockCounter = Counter.builder("ticket.purchase.failed")
+                .tag("reason", "insufficient_stock")
+                .description("Total failed ticket purchases due to insufficient stock")
+                .register(meterRegistry);
+
+        this.purchaseFailedAccessDeniedCounter = Counter.builder("ticket.purchase.failed")
+                .tag("reason", "access_denied")
+                .description("Total failed ticket purchases due to access denied")
+                .register(meterRegistry);
+
+        this.purchaseDurationTimer = Timer.builder("ticket.purchase.duration")
+                .description("Time taken for ticket purchase")
+                .publishPercentileHistogram()
+                .register(meterRegistry);
+    }
+
+    // Queue enter metrics
+    public void incrementQueueEnter(Long concertId) {
+        getOrCreateEnterCounter(concertId).increment();
+    }
+
+    public void incrementQueueRejected(Long concertId, String reason) {
+        getOrCreateRejectedCounter(concertId, reason).increment();
+    }
+
+    public void incrementProcessingEntered(Long concertId) {
+        getOrCreateProcessingEnteredCounter(concertId).increment();
+    }
+
+    // Waiting time metrics
+    public void recordWaitingTime(Long concertId, long waitingTimeMs) {
+        getOrCreateWaitingTimer(concertId).record(waitingTimeMs, TimeUnit.MILLISECONDS);
+    }
+
+    // Ticket purchase metrics
+    public void incrementPurchaseSuccess() {
+        purchaseSuccessCounter.increment();
+    }
+
+    public void incrementPurchaseFailedInsufficientStock() {
+        purchaseFailedInsufficientStockCounter.increment();
+    }
+
+    public void incrementPurchaseFailedAccessDenied() {
+        purchaseFailedAccessDeniedCounter.increment();
+    }
+
+    public Timer getPurchaseDurationTimer() {
+        return purchaseDurationTimer;
+    }
+
+    // Stock metrics
+    public void recordTicketSold(Long concertId, int quantity) {
+        getOrCreateStockSoldCounter(concertId).increment(quantity);
+        getOrCreateSoldQuantitySummary(concertId).record(quantity);
+    }
+
+    private Counter getOrCreateStockSoldCounter(Long concertId) {
+        String key = "sold:" + concertId;
+        return stockSoldCounters.computeIfAbsent(key, k ->
+                Counter.builder("ticket.stock.sold.total")
+                        .tag("concertId", String.valueOf(concertId))
+                        .description("Total tickets sold (throughput metric)")
+                        .register(meterRegistry)
+        );
+    }
+
+    private DistributionSummary getOrCreateSoldQuantitySummary(Long concertId) {
+        String key = "quantity:" + concertId;
+        return soldQuantitySummaries.computeIfAbsent(key, k ->
+                DistributionSummary.builder("ticket.sold.per.purchase")
+                        .tag("concertId", String.valueOf(concertId))
+                        .description("Tickets sold per purchase transaction")
+                        .publishPercentileHistogram()
+                        .register(meterRegistry)
+        );
+    }
+
+    private Counter getOrCreateEnterCounter(Long concertId) {
+        String key = "enter:" + concertId;
+        return enterCounters.computeIfAbsent(key, k ->
+                Counter.builder("queue.enter.total")
+                        .tag("concertId", String.valueOf(concertId))
+                        .description("Total queue enter requests")
+                        .register(meterRegistry)
+        );
+    }
+
+    private Counter getOrCreateRejectedCounter(Long concertId, String reason) {
+        String key = "rejected:" + concertId + ":" + reason;
+        return rejectedCounters.computeIfAbsent(key, k ->
+                Counter.builder("queue.enter.rejected")
+                        .tag("concertId", String.valueOf(concertId))
+                        .tag("reason", reason)
+                        .description("Total rejected queue entries")
+                        .register(meterRegistry)
+        );
+    }
+
+    private Counter getOrCreateProcessingEnteredCounter(Long concertId) {
+        String key = "processing:" + concertId;
+        return processingEnteredCounters.computeIfAbsent(key, k ->
+                Counter.builder("queue.processing.entered")
+                        .tag("concertId", String.valueOf(concertId))
+                        .description("Total users entered to processing")
+                        .register(meterRegistry)
+        );
+    }
+
+    private Timer getOrCreateWaitingTimer(Long concertId) {
+        String key = "waiting:" + concertId;
+        return waitingTimers.computeIfAbsent(key, k ->
+                Timer.builder("queue.waiting.time")
+                        .tag("concertId", String.valueOf(concertId))
+                        .description("Time spent waiting in queue")
+                        .publishPercentileHistogram()
+                        .register(meterRegistry)
+        );
+    }
+}

--- a/src/main/java/com/ticket_service/common/redis/RedissonLockTemplate.java
+++ b/src/main/java/com/ticket_service/common/redis/RedissonLockTemplate.java
@@ -64,4 +64,25 @@ public class RedissonLockTemplate {
             }
         }
     }
+
+    public void tryExecuteWithLock(String key, Runnable action) {
+        RLock lock = redissonClient.getLock(key);
+        boolean locked = false;
+
+        try {
+            locked = lock.tryLock(0, leaseTime.toMillis(), TimeUnit.MILLISECONDS);
+
+            if (!locked) {
+                return;
+            }
+
+            action.run();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (locked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
 }

--- a/src/main/java/com/ticket_service/queue/exception/QueueExceptionHandler.java
+++ b/src/main/java/com/ticket_service/queue/exception/QueueExceptionHandler.java
@@ -31,4 +31,11 @@ public class QueueExceptionHandler {
         log.debug("Not in queue: {}", e.getMessage());
         return ApiResponse.of(HttpStatus.NOT_FOUND, e.getMessage(), null);
     }
+
+    @ExceptionHandler(QueueFullException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    public ApiResponse<Void> handleQueueFull(QueueFullException e) {
+        log.warn("Queue full: {}", e.getMessage());
+        return ApiResponse.of(HttpStatus.SERVICE_UNAVAILABLE, e.getMessage(), null);
+    }
 }

--- a/src/main/java/com/ticket_service/queue/exception/QueueExceptionHandler.java
+++ b/src/main/java/com/ticket_service/queue/exception/QueueExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.ticket_service.queue.exception;
 
 import com.ticket_service.common.dto.ApiResponse;
+import com.ticket_service.common.metrics.QueueMetrics;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,7 +11,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice(basePackages = "com.ticket_service.queue")
+@RequiredArgsConstructor
 public class QueueExceptionHandler {
+
+    private final QueueMetrics queueMetrics;
 
     @ExceptionHandler(AlreadyInQueueException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
@@ -22,6 +27,7 @@ public class QueueExceptionHandler {
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ApiResponse<Void> handleQueueAccessDenied(QueueAccessDeniedException e) {
         log.debug("Queue access denied: {}", e.getMessage());
+        queueMetrics.incrementPurchaseFailedAccessDenied();
         return ApiResponse.of(HttpStatus.FORBIDDEN, e.getMessage(), null);
     }
 

--- a/src/main/java/com/ticket_service/queue/exception/QueueFullException.java
+++ b/src/main/java/com/ticket_service/queue/exception/QueueFullException.java
@@ -1,0 +1,7 @@
+package com.ticket_service.queue.exception;
+
+public class QueueFullException extends RuntimeException {
+    public QueueFullException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ticket_service/queue/service/PolledUser.java
+++ b/src/main/java/com/ticket_service/queue/service/PolledUser.java
@@ -1,0 +1,4 @@
+package com.ticket_service.queue.service;
+
+public record PolledUser(String userId, long waitingTimeMs) {
+}

--- a/src/main/java/com/ticket_service/queue/service/QueueEventPublisher.java
+++ b/src/main/java/com/ticket_service/queue/service/QueueEventPublisher.java
@@ -6,6 +6,7 @@ import com.ticket_service.queue.service.dto.QueueEnterMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,6 +19,7 @@ public class QueueEventPublisher {
     private final RedisTemplate<String, String> queueRedisTemplate;
     private final ObjectMapper objectMapper;
 
+    @Async("sseTaskExecutor")
     public void publishEnterEvent(Long concertId, String userId) {
         try {
             QueueEnterMessage message = QueueEnterMessage.of(concertId, userId);

--- a/src/main/java/com/ticket_service/queue/service/QueueEventSubscriber.java
+++ b/src/main/java/com/ticket_service/queue/service/QueueEventSubscriber.java
@@ -40,16 +40,16 @@ public class QueueEventSubscriber implements MessageListener {
             Long concertId = enterMessage.getConcertId();
             String userId = enterMessage.getUserId();
 
-            boolean sent = sseEmitterService.sendEventAndComplete(
+            sseEmitterService.sendEventAndCompleteAsync(
                     concertId,
                     userId,
                     QueueEventType.ENTER,
                     QueueEnterEvent.processing()
-            );
-
-            if (sent) {
-                log.info("[SUB] 입장 이벤트 전송 성공: concertId={}, userId={}", concertId, userId);
-            }
+            ).thenAccept(sent -> {
+                if (sent) {
+                    log.info("[SUB] 입장 이벤트 전송 성공: concertId={}, userId={}", concertId, userId);
+                }
+            });
         } catch (Exception e) {
             log.error("입장 이벤트 처리 실패", e);
         }

--- a/src/main/java/com/ticket_service/queue/service/QueueOrchestrationService.java
+++ b/src/main/java/com/ticket_service/queue/service/QueueOrchestrationService.java
@@ -1,6 +1,5 @@
 package com.ticket_service.queue.service;
 
-import com.ticket_service.queue.service.dto.QueueEnterEvent;
 import com.ticket_service.queue.service.dto.QueueEventType;
 import com.ticket_service.queue.service.dto.QueuePositionEvent;
 import lombok.RequiredArgsConstructor;
@@ -64,14 +63,14 @@ public class QueueOrchestrationService {
     }
 
     /**
-     * 다음 대기자들을 입장시키고 입장 완료 SSE 이벤트를 전송한다.
+     * 다음 대기자들을 입장시키고 Redis Pub/Sub으로 입장 이벤트를 발행한다.
+     * 각 서버의 QueueEventSubscriber가 메시지를 받아 해당 사용자에게 SSE를 전송한다.
      * 순번 업데이트는 QueuePositionBatchScheduler에서 주기적으로 처리한다.
      */
     private void enterNextAndNotify(Long concertId) {
         List<String> enteredUsers = queueService.permitProcessing(concertId);
-        for (String enteredUserId : enteredUsers) {
-            sseEmitterService.sendEvent(concertId, enteredUserId, QueueEventType.ENTER, QueueEnterEvent.processing());
-            sseEmitterService.completeEmitter(concertId, enteredUserId);
-        }
+        enteredUsers.forEach(enteredUserId ->
+                queueEventPublisher.publishEnterEvent(concertId, enteredUserId)
+        );
     }
 }

--- a/src/main/java/com/ticket_service/queue/service/QueuePositionBatchScheduler.java
+++ b/src/main/java/com/ticket_service/queue/service/QueuePositionBatchScheduler.java
@@ -25,8 +25,8 @@ public class QueuePositionBatchScheduler {
             try {
                 List<String> waitingUsers = queueService.getWaitingUsers(concertId);
                 if (!waitingUsers.isEmpty()) {
-                    sseEmitterService.broadcastPositions(concertId, waitingUsers);
-                    log.debug("순번 브로드캐스트 완료: concertId={}, userCount={}", concertId, waitingUsers.size());
+                    sseEmitterService.broadcastPositionsAsync(concertId, waitingUsers)
+                            .thenRun(() -> log.debug("순번 브로드캐스트 완료: concertId={}, userCount={}", concertId, waitingUsers.size()));
                 }
             } catch (Exception e) {
                 log.error("순번 브로드캐스트 실패: concertId={}", concertId, e);

--- a/src/main/java/com/ticket_service/queue/service/RedisQueueService.java
+++ b/src/main/java/com/ticket_service/queue/service/RedisQueueService.java
@@ -3,6 +3,7 @@ package com.ticket_service.queue.service;
 import com.ticket_service.common.redis.LockKey;
 import com.ticket_service.common.redis.RedissonLockTemplate;
 import com.ticket_service.queue.exception.AlreadyInQueueException;
+import com.ticket_service.queue.exception.QueueFullException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,7 +22,7 @@ public class RedisQueueService implements QueueService {
         return redissonLockTemplate.executeWithLock(
                 LockKey.queueUser(concertId, userId),
                 () -> {
-                    validateUniqueEntry(concertId, userId);
+                    validateEntry(concertId, userId);
                     waitingQueue.add(concertId, userId);
                     return getPosition(concertId, userId);
                 }
@@ -93,12 +94,15 @@ public class RedisQueueService implements QueueService {
         return userId;
     }
 
-    private void validateUniqueEntry(Long concertId, String userId) {
+    private void validateEntry(Long concertId, String userId) {
         if (processingSet.contains(concertId, userId)) {
             throw new AlreadyInQueueException("이미 입장한 사용자입니다.");
         }
         if (waitingQueue.contains(concertId, userId)) {
             throw new AlreadyInQueueException("이미 대기열에 등록된 사용자입니다.");
+        }
+        if (!waitingQueue.hasCapacity(concertId)) {
+            throw new QueueFullException("현재 대기 인원이 많아 접수가 어렵습니다. 잠시 후 다시 시도해주세요.");
         }
     }
 }

--- a/src/main/java/com/ticket_service/queue/service/RedisQueueService.java
+++ b/src/main/java/com/ticket_service/queue/service/RedisQueueService.java
@@ -1,5 +1,6 @@
 package com.ticket_service.queue.service;
 
+import com.ticket_service.common.metrics.QueueMetrics;
 import com.ticket_service.common.redis.LockKey;
 import com.ticket_service.common.redis.RedissonLockTemplate;
 import com.ticket_service.queue.exception.AlreadyInQueueException;
@@ -16,6 +17,7 @@ public class RedisQueueService implements QueueService {
     private final WaitingQueue waitingQueue;
     private final ProcessingSet processingSet;
     private final RedissonLockTemplate redissonLockTemplate;
+    private final QueueMetrics queueMetrics;
 
     @Override
     public Long enterWaitingQueue(Long concertId, String userId) {
@@ -24,6 +26,7 @@ public class RedisQueueService implements QueueService {
                 () -> {
                     validateEntry(concertId, userId);
                     waitingQueue.add(concertId, userId);
+                    queueMetrics.incrementQueueEnter(concertId);
                     return getPosition(concertId, userId);
                 }
         );
@@ -75,11 +78,23 @@ public class RedisQueueService implements QueueService {
             return List.of();
         }
 
-        List<String> enteredUsers = waitingQueue.pollTopUsers(concertId, limit);
-        if (!enteredUsers.isEmpty()) {
-            processingSet.addAll(concertId, enteredUsers);
+        List<PolledUser> polledUsers = waitingQueue.pollTopUsersWithWaitingTime(concertId, limit);
+        if (polledUsers.isEmpty()) {
+            return List.of();
         }
-        return enteredUsers;
+
+        List<String> userIds = polledUsers.stream()
+                .map(PolledUser::userId)
+                .toList();
+
+        processingSet.addAll(concertId, userIds);
+
+        for (PolledUser polledUser : polledUsers) {
+            queueMetrics.recordWaitingTime(concertId, polledUser.waitingTimeMs());
+            queueMetrics.incrementProcessingEntered(concertId);
+        }
+
+        return userIds;
     }
 
     private String moveOneToProcessing(Long concertId) {
@@ -87,21 +102,27 @@ public class RedisQueueService implements QueueService {
             return null;
         }
 
-        String userId = waitingQueue.pollTopUser(concertId);
-        if (userId != null) {
-            processingSet.add(concertId, userId);
+        PolledUser polledUser = waitingQueue.pollTopUserWithWaitingTime(concertId);
+        if (polledUser != null) {
+            processingSet.add(concertId, polledUser.userId());
+            queueMetrics.recordWaitingTime(concertId, polledUser.waitingTimeMs());
+            queueMetrics.incrementProcessingEntered(concertId);
+            return polledUser.userId();
         }
-        return userId;
+        return null;
     }
 
     private void validateEntry(Long concertId, String userId) {
         if (processingSet.contains(concertId, userId)) {
+            queueMetrics.incrementQueueRejected(concertId, "duplicate");
             throw new AlreadyInQueueException("이미 입장한 사용자입니다.");
         }
         if (waitingQueue.contains(concertId, userId)) {
+            queueMetrics.incrementQueueRejected(concertId, "duplicate");
             throw new AlreadyInQueueException("이미 대기열에 등록된 사용자입니다.");
         }
         if (!waitingQueue.hasCapacity(concertId)) {
+            queueMetrics.incrementQueueRejected(concertId, "full");
             throw new QueueFullException("현재 대기 인원이 많아 접수가 어렵습니다. 잠시 후 다시 시도해주세요.");
         }
     }

--- a/src/main/java/com/ticket_service/queue/service/SseEmitterService.java
+++ b/src/main/java/com/ticket_service/queue/service/SseEmitterService.java
@@ -7,11 +7,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -23,6 +28,11 @@ public class SseEmitterService {
     private Duration sseTimeout;
 
     private final ConcurrentHashMap<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Executor sseTaskExecutor;
+
+    public SseEmitterService(@Qualifier("sseTaskExecutor") Executor sseTaskExecutor) {
+        this.sseTaskExecutor = sseTaskExecutor;
+    }
 
     public SseEmitter createEmitter(Long concertId, String userId) {
         String key = buildKey(concertId, userId);
@@ -56,6 +66,16 @@ public class SseEmitterService {
     }
 
     /**
+     * 비동기로 SSE 이벤트를 전송한다.
+     */
+    public CompletableFuture<Void> sendEventAsync(Long concertId, String userId, QueueEventType eventType, Object data) {
+        return CompletableFuture.runAsync(
+                () -> sendEvent(concertId, userId, eventType, data),
+                sseTaskExecutor
+        );
+    }
+
+    /**
      * 이벤트 전송 후 emitter를 완료 처리한다. (원자적 연산)
      * Pub/Sub에서 enter 이벤트 수신 시 사용한다.
      *
@@ -81,6 +101,16 @@ public class SseEmitterService {
         return sent.get();
     }
 
+    /**
+     * 비동기로 이벤트 전송 후 emitter를 완료 처리한다.
+     */
+    public CompletableFuture<Boolean> sendEventAndCompleteAsync(Long concertId, String userId, QueueEventType eventType, Object data) {
+        return CompletableFuture.supplyAsync(
+                () -> sendEventAndComplete(concertId, userId, eventType, data),
+                sseTaskExecutor
+        );
+    }
+
     public void completeEmitter(Long concertId, String userId) {
         String key = buildKey(concertId, userId);
         emitters.computeIfPresent(key, (k, emitter) -> {
@@ -103,6 +133,25 @@ public class SseEmitterService {
         for (int i = 0; i < waitingUsers.size(); i++) {
             sendEvent(concertId, waitingUsers.get(i), QueueEventType.QUEUE_POSITION, new QueuePositionEvent(i));
         }
+    }
+
+    /**
+     * 비동기로 모든 대기자에게 순번 정보를 병렬 전송한다.
+     * 모든 전송이 완료될 때까지 기다린다.
+     */
+    public CompletableFuture<Void> broadcastPositionsAsync(Long concertId, List<String> waitingUsers) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (int i = 0; i < waitingUsers.size(); i++) {
+            final int position = i;
+            CompletableFuture<Void> future = CompletableFuture.runAsync(
+                    () -> sendEvent(concertId, waitingUsers.get(position), QueueEventType.QUEUE_POSITION, new QueuePositionEvent(position)),
+                    sseTaskExecutor
+            );
+            futures.add(future);
+        }
+
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
     }
 
     private void registerCallbacks(SseEmitter emitter, String key, Long concertId, String userId) {

--- a/src/main/java/com/ticket_service/queue/service/SseEmitterService.java
+++ b/src/main/java/com/ticket_service/queue/service/SseEmitterService.java
@@ -129,6 +129,10 @@ public class SseEmitterService {
                 .collect(Collectors.toSet());
     }
 
+    public int getActiveConnectionCount() {
+        return emitters.size();
+    }
+
     public void broadcastPositions(Long concertId, List<String> waitingUsers) {
         for (int i = 0; i < waitingUsers.size(); i++) {
             sendEvent(concertId, waitingUsers.get(i), QueueEventType.QUEUE_POSITION, new QueuePositionEvent(i));

--- a/src/main/java/com/ticket_service/queue/service/WaitingQueue.java
+++ b/src/main/java/com/ticket_service/queue/service/WaitingQueue.java
@@ -4,6 +4,7 @@ import com.ticket_service.common.redis.QueueKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -92,5 +93,49 @@ public class WaitingQueue {
         String userId = users.iterator().next();
         queueRedisTemplate.opsForZSet().remove(key, userId);
         return userId;
+    }
+
+    public List<PolledUser> pollTopUsersWithWaitingTime(Long concertId, long count) {
+        String key = QueueKey.waitingQueue(concertId);
+        Set<TypedTuple<String>> usersWithScores = queueRedisTemplate.opsForZSet().rangeWithScores(key, 0, count - 1);
+
+        if (usersWithScores == null || usersWithScores.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        long currentTime = System.currentTimeMillis();
+        List<PolledUser> result = new ArrayList<>();
+
+        for (TypedTuple<String> tuple : usersWithScores) {
+            String userId = tuple.getValue();
+            Double score = tuple.getScore();
+            if (userId != null) {
+                queueRedisTemplate.opsForZSet().remove(key, userId);
+                long waitingTimeMs = score != null ? currentTime - score.longValue() : 0L;
+                result.add(new PolledUser(userId, waitingTimeMs));
+            }
+        }
+        return result;
+    }
+
+    public PolledUser pollTopUserWithWaitingTime(Long concertId) {
+        String key = QueueKey.waitingQueue(concertId);
+        Set<TypedTuple<String>> usersWithScores = queueRedisTemplate.opsForZSet().rangeWithScores(key, 0, 0);
+
+        if (usersWithScores == null || usersWithScores.isEmpty()) {
+            return null;
+        }
+
+        TypedTuple<String> tuple = usersWithScores.iterator().next();
+        String userId = tuple.getValue();
+        Double score = tuple.getScore();
+
+        if (userId != null) {
+            queueRedisTemplate.opsForZSet().remove(key, userId);
+            long currentTime = System.currentTimeMillis();
+            long waitingTimeMs = score != null ? currentTime - score.longValue() : 0L;
+            return new PolledUser(userId, waitingTimeMs);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/ticket_service/queue/service/WaitingQueue.java
+++ b/src/main/java/com/ticket_service/queue/service/WaitingQueue.java
@@ -22,9 +22,22 @@ public class WaitingQueue {
     @Value("${queue.waiting-timeout}")
     private Duration waitingTimeout;
 
+    @Value("${queue.max-waiting-count:20000}")
+    private int maxWaitingCount;
+
     public boolean contains(Long concertId, String userId) {
         String key = QueueKey.waitingQueue(concertId);
         return queueRedisTemplate.opsForZSet().score(key, userId) != null;
+    }
+
+    public long size(Long concertId) {
+        String key = QueueKey.waitingQueue(concertId);
+        Long size = queueRedisTemplate.opsForZSet().zCard(key);
+        return size != null ? size : 0L;
+    }
+
+    public boolean hasCapacity(Long concertId) {
+        return size(concertId) < maxWaitingCount;
     }
 
     public void add(Long concertId, String userId) {

--- a/src/main/java/com/ticket_service/ticket/exception/TicketExceptionHandler.java
+++ b/src/main/java/com/ticket_service/ticket/exception/TicketExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.ticket_service.ticket.exception;
 
 import com.ticket_service.common.dto.ApiResponse;
+import com.ticket_service.common.metrics.QueueMetrics;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,12 +11,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice(basePackages = "com.ticket_service.ticket")
+@RequiredArgsConstructor
 public class TicketExceptionHandler {
+
+    private final QueueMetrics queueMetrics;
+
     @ExceptionHandler(InsufficientTicketStockException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ApiResponse<Void> handleInsufficientStock(InsufficientTicketStockException e) {
         log.debug("Ticket stock exhausted: {}", e.getMessage());
-
+        queueMetrics.incrementPurchaseFailedInsufficientStock();
         return ApiResponse.of(HttpStatus.CONFLICT, e.getMessage(), null);
     }
 }

--- a/src/main/java/com/ticket_service/ticket/service/TicketPurchaseService.java
+++ b/src/main/java/com/ticket_service/ticket/service/TicketPurchaseService.java
@@ -1,7 +1,10 @@
 package com.ticket_service.ticket.service;
 
+import com.ticket_service.common.metrics.QueueMetrics;
 import com.ticket_service.queue.exception.QueueAccessDeniedException;
 import com.ticket_service.queue.service.QueueOrchestrationService;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,14 +16,19 @@ public class TicketPurchaseService {
 
     private final QueueOrchestrationService queueOrchestrationService;
     private final TicketStockService ticketStockService;
+    private final QueueMetrics queueMetrics;
 
     public void purchase(Long concertId, String userId, int quantity) {
         validateQueueAccess(concertId, userId);
 
+        Sample sample = Timer.start();
         try {
             ticketStockService.decreaseByConcertId(concertId, quantity);
+            queueMetrics.incrementPurchaseSuccess();
+            queueMetrics.recordTicketSold(concertId, quantity);
             log.info("concertId : {}, userId : {}", concertId, userId);
         } finally {
+            sample.stop(queueMetrics.getPurchaseDurationTimer());
             queueOrchestrationService.onPurchaseComplete(concertId, userId);
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ redis:
 
 queue:
   max-processing-count: 200
+  max-waiting-count: 20000
   entry-timeout: 5m
   waiting-timeout: 30m
   sse-timeout: 10m

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,11 +19,17 @@ redis:
     lease-time: 3s
 
 queue:
-  max-processing-count: 100
+  max-processing-count: 200
   entry-timeout: 5m
   waiting-timeout: 30m
   sse-timeout: 10m
   position-broadcast-interval: 5s
+
+sse:
+  thread-pool:
+    core-size: 10
+    max-size: 50
+    queue-capacity: 100
 management:
   endpoints:
     web:

--- a/src/test/java/com/ticket_service/queue/service/QueueOrchestrationServiceTest.java
+++ b/src/test/java/com/ticket_service/queue/service/QueueOrchestrationServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -53,6 +54,9 @@ class QueueOrchestrationServiceTest {
             given(queueService.enterWaitingQueue(CONCERT_ID, USER_ID)).willReturn(0L);
             given(queueService.hasProcessingCapacity(CONCERT_ID)).willReturn(true);
             given(queueService.permitProcessing(CONCERT_ID)).willReturn(List.of(USER_ID));
+            given(sseEmitterService.sendEventAsync(eq(CONCERT_ID), eq(USER_ID),
+                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class)))
+                    .willReturn(CompletableFuture.completedFuture(null));
 
             // when
             SseEmitter result = queueOrchestrationService.registerAndSubscribe(CONCERT_ID, USER_ID);
@@ -65,7 +69,7 @@ class QueueOrchestrationServiceTest {
             inOrder.verify(queueService).enterWaitingQueue(CONCERT_ID, USER_ID);
             inOrder.verify(queueService).hasProcessingCapacity(CONCERT_ID);
             inOrder.verify(queueService).permitProcessing(CONCERT_ID);
-            inOrder.verify(sseEmitterService).sendEvent(eq(CONCERT_ID), eq(USER_ID),
+            inOrder.verify(sseEmitterService).sendEventAsync(eq(CONCERT_ID), eq(USER_ID),
                     eq(QueueEventType.ENTER), any(QueueEnterEvent.class));
             inOrder.verify(sseEmitterService).completeEmitter(CONCERT_ID, USER_ID);
         }
@@ -99,6 +103,9 @@ class QueueOrchestrationServiceTest {
         void onPurchaseComplete_success() {
             // given
             given(queueService.permitProcessing(CONCERT_ID)).willReturn(List.of("user-2"));
+            given(sseEmitterService.sendEventAsync(eq(CONCERT_ID), eq("user-2"),
+                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class)))
+                    .willReturn(CompletableFuture.completedFuture(null));
 
             // when
             queueOrchestrationService.onPurchaseComplete(CONCERT_ID, USER_ID);
@@ -107,7 +114,7 @@ class QueueOrchestrationServiceTest {
             InOrder inOrder = inOrder(queueService, sseEmitterService);
             inOrder.verify(queueService).completeProcessing(CONCERT_ID, USER_ID);
             inOrder.verify(queueService).permitProcessing(CONCERT_ID);
-            inOrder.verify(sseEmitterService).sendEvent(eq(CONCERT_ID), eq("user-2"),
+            inOrder.verify(sseEmitterService).sendEventAsync(eq(CONCERT_ID), eq("user-2"),
                     eq(QueueEventType.ENTER), any(QueueEnterEvent.class));
             inOrder.verify(sseEmitterService).completeEmitter(CONCERT_ID, "user-2");
         }
@@ -122,6 +129,9 @@ class QueueOrchestrationServiceTest {
         void onCancel_success() {
             // given
             given(queueService.permitProcessing(CONCERT_ID)).willReturn(List.of("user-2"));
+            given(sseEmitterService.sendEventAsync(eq(CONCERT_ID), eq("user-2"),
+                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class)))
+                    .willReturn(CompletableFuture.completedFuture(null));
 
             // when
             queueOrchestrationService.onCancel(CONCERT_ID, USER_ID);
@@ -131,7 +141,7 @@ class QueueOrchestrationServiceTest {
             inOrder.verify(queueService).removeFromQueue(CONCERT_ID, USER_ID);
             inOrder.verify(sseEmitterService).completeEmitter(CONCERT_ID, USER_ID);
             inOrder.verify(queueService).permitProcessing(CONCERT_ID);
-            inOrder.verify(sseEmitterService).sendEvent(eq(CONCERT_ID), eq("user-2"),
+            inOrder.verify(sseEmitterService).sendEventAsync(eq(CONCERT_ID), eq("user-2"),
                     eq(QueueEventType.ENTER), any(QueueEnterEvent.class));
             inOrder.verify(sseEmitterService).completeEmitter(CONCERT_ID, "user-2");
         }

--- a/src/test/java/com/ticket_service/queue/service/QueueOrchestrationServiceTest.java
+++ b/src/test/java/com/ticket_service/queue/service/QueueOrchestrationServiceTest.java
@@ -1,6 +1,5 @@
 package com.ticket_service.queue.service;
 
-import com.ticket_service.queue.service.dto.QueueEnterEvent;
 import com.ticket_service.queue.service.dto.QueueEventType;
 import com.ticket_service.queue.service.dto.QueuePositionEvent;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -45,7 +43,7 @@ class QueueOrchestrationServiceTest {
     @DisplayName("registerAndSubscribe 메서드")
     class RegisterAndSubscribeTest {
 
-        @DisplayName("처리열에 여유가 있으면 1명 입장 처리 후 SSE 종료한다")
+        @DisplayName("처리열에 여유가 있으면 1명 입장 처리 후 Redis Pub/Sub으로 입장 이벤트를 발행한다")
         @Test
         void registerAndSubscribe_with_capacity() {
             // given
@@ -54,9 +52,6 @@ class QueueOrchestrationServiceTest {
             given(queueService.enterWaitingQueue(CONCERT_ID, USER_ID)).willReturn(0L);
             given(queueService.hasProcessingCapacity(CONCERT_ID)).willReturn(true);
             given(queueService.permitProcessing(CONCERT_ID)).willReturn(List.of(USER_ID));
-            given(sseEmitterService.sendEventAsync(eq(CONCERT_ID), eq(USER_ID),
-                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class)))
-                    .willReturn(CompletableFuture.completedFuture(null));
 
             // when
             SseEmitter result = queueOrchestrationService.registerAndSubscribe(CONCERT_ID, USER_ID);
@@ -64,14 +59,12 @@ class QueueOrchestrationServiceTest {
             // then
             assertThat(result).isSameAs(mockEmitter);
 
-            InOrder inOrder = inOrder(queueService, sseEmitterService);
+            InOrder inOrder = inOrder(queueService, sseEmitterService, queueEventPublisher);
             inOrder.verify(sseEmitterService).createEmitter(CONCERT_ID, USER_ID);
             inOrder.verify(queueService).enterWaitingQueue(CONCERT_ID, USER_ID);
             inOrder.verify(queueService).hasProcessingCapacity(CONCERT_ID);
             inOrder.verify(queueService).permitProcessing(CONCERT_ID);
-            inOrder.verify(sseEmitterService).sendEventAsync(eq(CONCERT_ID), eq(USER_ID),
-                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class));
-            inOrder.verify(sseEmitterService).completeEmitter(CONCERT_ID, USER_ID);
+            inOrder.verify(queueEventPublisher).publishEnterEvent(CONCERT_ID, USER_ID);
         }
 
         @DisplayName("처리열이 가득 차면 대기 순번 이벤트만 전송한다")
@@ -98,25 +91,20 @@ class QueueOrchestrationServiceTest {
     @DisplayName("onPurchaseComplete 메서드")
     class OnPurchaseCompleteTest {
 
-        @DisplayName("구매 완료 시 complete → 다음 대기자 1명 입장 및 SSE 종료")
+        @DisplayName("구매 완료 시 complete → 다음 대기자 입장 이벤트 발행")
         @Test
         void onPurchaseComplete_success() {
             // given
             given(queueService.permitProcessing(CONCERT_ID)).willReturn(List.of("user-2"));
-            given(sseEmitterService.sendEventAsync(eq(CONCERT_ID), eq("user-2"),
-                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class)))
-                    .willReturn(CompletableFuture.completedFuture(null));
 
             // when
             queueOrchestrationService.onPurchaseComplete(CONCERT_ID, USER_ID);
 
             // then
-            InOrder inOrder = inOrder(queueService, sseEmitterService);
+            InOrder inOrder = inOrder(queueService, queueEventPublisher);
             inOrder.verify(queueService).completeProcessing(CONCERT_ID, USER_ID);
             inOrder.verify(queueService).permitProcessing(CONCERT_ID);
-            inOrder.verify(sseEmitterService).sendEventAsync(eq(CONCERT_ID), eq("user-2"),
-                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class));
-            inOrder.verify(sseEmitterService).completeEmitter(CONCERT_ID, "user-2");
+            inOrder.verify(queueEventPublisher).publishEnterEvent(CONCERT_ID, "user-2");
         }
     }
 
@@ -124,26 +112,21 @@ class QueueOrchestrationServiceTest {
     @DisplayName("onCancel 메서드")
     class OnCancelTest {
 
-        @DisplayName("취소 시 dequeue → SSE 종료 → 다음 대기자 1명 입장 및 SSE 종료")
+        @DisplayName("취소 시 dequeue → SSE 종료 → 다음 대기자 입장 이벤트 발행")
         @Test
         void onCancel_success() {
             // given
             given(queueService.permitProcessing(CONCERT_ID)).willReturn(List.of("user-2"));
-            given(sseEmitterService.sendEventAsync(eq(CONCERT_ID), eq("user-2"),
-                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class)))
-                    .willReturn(CompletableFuture.completedFuture(null));
 
             // when
             queueOrchestrationService.onCancel(CONCERT_ID, USER_ID);
 
             // then
-            InOrder inOrder = inOrder(queueService, sseEmitterService);
+            InOrder inOrder = inOrder(queueService, sseEmitterService, queueEventPublisher);
             inOrder.verify(queueService).removeFromQueue(CONCERT_ID, USER_ID);
             inOrder.verify(sseEmitterService).completeEmitter(CONCERT_ID, USER_ID);
             inOrder.verify(queueService).permitProcessing(CONCERT_ID);
-            inOrder.verify(sseEmitterService).sendEventAsync(eq(CONCERT_ID), eq("user-2"),
-                    eq(QueueEventType.ENTER), any(QueueEnterEvent.class));
-            inOrder.verify(sseEmitterService).completeEmitter(CONCERT_ID, "user-2");
+            inOrder.verify(queueEventPublisher).publishEnterEvent(CONCERT_ID, "user-2");
         }
     }
 }

--- a/src/test/java/com/ticket_service/queue/service/RedisQueueServiceTest.java
+++ b/src/test/java/com/ticket_service/queue/service/RedisQueueServiceTest.java
@@ -1,5 +1,6 @@
 package com.ticket_service.queue.service;
 
+import com.ticket_service.common.metrics.QueueMetrics;
 import com.ticket_service.common.redis.RedissonLockTemplate;
 import com.ticket_service.queue.exception.AlreadyInQueueException;
 import com.ticket_service.queue.exception.QueueFullException;
@@ -38,6 +39,9 @@ class RedisQueueServiceTest {
     @Mock
     private RedissonLockTemplate redissonLockTemplate;
 
+    @Mock
+    private QueueMetrics queueMetrics;
+
     private RedisQueueService redisQueueService;
 
     private static final Long CONCERT_ID = 1L;
@@ -45,7 +49,7 @@ class RedisQueueServiceTest {
 
     @BeforeEach
     void setUp() {
-        redisQueueService = new RedisQueueService(waitingQueue, processingSet, redissonLockTemplate);
+        redisQueueService = new RedisQueueService(waitingQueue, processingSet, redissonLockTemplate, queueMetrics);
 
         given(redissonLockTemplate.executeWithLock(anyString(), any(Supplier.class)))
                 .willAnswer(invocation -> {
@@ -171,12 +175,19 @@ class RedisQueueServiceTest {
         @Test
         void enterNextUsers_success() {
             given(processingSet.remainingCapacity(CONCERT_ID)).willReturn(5L);
-            given(waitingQueue.pollTopUsers(CONCERT_ID, 5)).willReturn(List.of("user-1", "user-2", "user-3"));
+            given(waitingQueue.pollTopUsersWithWaitingTime(CONCERT_ID, 5)).willReturn(List.of(
+                    new PolledUser("user-1", 1000L),
+                    new PolledUser("user-2", 2000L),
+                    new PolledUser("user-3", 3000L)
+            ));
 
             List<String> enteredUsers = redisQueueService.permitProcessing(CONCERT_ID);
 
             assertThat(enteredUsers).containsExactly("user-1", "user-2", "user-3");
             verify(processingSet).addAll(CONCERT_ID, List.of("user-1", "user-2", "user-3"));
+            verify(queueMetrics).recordWaitingTime(CONCERT_ID, 1000L);
+            verify(queueMetrics).recordWaitingTime(CONCERT_ID, 2000L);
+            verify(queueMetrics).recordWaitingTime(CONCERT_ID, 3000L);
         }
 
         @DisplayName("가용 슬롯이 없으면 빈 목록 반환")
@@ -187,14 +198,14 @@ class RedisQueueServiceTest {
             List<String> enteredUsers = redisQueueService.permitProcessing(CONCERT_ID);
 
             assertThat(enteredUsers).isEmpty();
-            verify(waitingQueue, never()).pollTopUsers(anyLong(), anyLong());
+            verify(waitingQueue, never()).pollTopUsersWithWaitingTime(anyLong(), anyLong());
         }
 
         @DisplayName("대기열이 비어있으면 빈 목록 반환")
         @Test
         void enterNextUsers_empty_waiting_queue() {
             given(processingSet.remainingCapacity(CONCERT_ID)).willReturn(100L);
-            given(waitingQueue.pollTopUsers(CONCERT_ID, 100)).willReturn(List.of());
+            given(waitingQueue.pollTopUsersWithWaitingTime(CONCERT_ID, 100)).willReturn(List.of());
 
             List<String> enteredUsers = redisQueueService.permitProcessing(CONCERT_ID);
 

--- a/src/test/java/com/ticket_service/queue/service/RedisQueueServiceTest.java
+++ b/src/test/java/com/ticket_service/queue/service/RedisQueueServiceTest.java
@@ -2,6 +2,7 @@ package com.ticket_service.queue.service;
 
 import com.ticket_service.common.redis.RedissonLockTemplate;
 import com.ticket_service.queue.exception.AlreadyInQueueException;
+import com.ticket_service.queue.exception.QueueFullException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -67,12 +68,25 @@ class RedisQueueServiceTest {
         void enqueue_success_first_user() {
             given(processingSet.contains(CONCERT_ID, USER_ID)).willReturn(false);
             given(waitingQueue.contains(CONCERT_ID, USER_ID)).willReturn(false);
+            given(waitingQueue.hasCapacity(CONCERT_ID)).willReturn(true);
             given(waitingQueue.rank(CONCERT_ID, USER_ID)).willReturn(0L);
 
             Long position = redisQueueService.enterWaitingQueue(CONCERT_ID, USER_ID);
 
             assertThat(position).isEqualTo(0L);
             verify(waitingQueue).add(CONCERT_ID, USER_ID);
+        }
+
+        @DisplayName("대기열 등록 실패 - 대기열이 가득 참")
+        @Test
+        void enqueue_fail_queue_full() {
+            given(processingSet.contains(CONCERT_ID, USER_ID)).willReturn(false);
+            given(waitingQueue.contains(CONCERT_ID, USER_ID)).willReturn(false);
+            given(waitingQueue.hasCapacity(CONCERT_ID)).willReturn(false);
+
+            assertThatThrownBy(() -> redisQueueService.enterWaitingQueue(CONCERT_ID, USER_ID))
+                    .isInstanceOf(QueueFullException.class)
+                    .hasMessage("현재 대기 인원이 많아 접수가 어렵습니다. 잠시 후 다시 시도해주세요.");
         }
 
         @DisplayName("대기열 등록 실패 - 이미 처리중인 사용자")

--- a/src/test/java/com/ticket_service/queue/service/SseEmitterServiceTest.java
+++ b/src/test/java/com/ticket_service/queue/service/SseEmitterServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.Duration;
+import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,7 +22,8 @@ class SseEmitterServiceTest {
 
     @BeforeEach
     void setUp() {
-        sseEmitterService = new SseEmitterService();
+        Executor directExecutor = Runnable::run;
+        sseEmitterService = new SseEmitterService(directExecutor);
         ReflectionTestUtils.setField(sseEmitterService, "sseTimeout", Duration.ofMinutes(10));
     }
 

--- a/src/test/java/com/ticket_service/ticket/service/TicketPurchaseServiceTest.java
+++ b/src/test/java/com/ticket_service/ticket/service/TicketPurchaseServiceTest.java
@@ -1,8 +1,10 @@
 package com.ticket_service.ticket.service;
 
+import com.ticket_service.common.metrics.QueueMetrics;
 import com.ticket_service.queue.exception.QueueAccessDeniedException;
 import com.ticket_service.queue.service.QueueOrchestrationService;
 import com.ticket_service.ticket.exception.InsufficientTicketStockException;
+import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -26,6 +29,9 @@ class TicketPurchaseServiceTest {
 
     @Mock
     private TicketStockService ticketStockService;
+
+    @Mock
+    private QueueMetrics queueMetrics;
 
     @InjectMocks
     private TicketPurchaseService ticketPurchaseService;
@@ -39,6 +45,7 @@ class TicketPurchaseServiceTest {
     void purchase_success() {
         // given
         given(queueOrchestrationService.isInProcessing(CONCERT_ID, USER_ID)).willReturn(true);
+        given(queueMetrics.getPurchaseDurationTimer()).willReturn(mock(Timer.class));
 
         // when
         ticketPurchaseService.purchase(CONCERT_ID, USER_ID, QUANTITY);
@@ -71,6 +78,7 @@ class TicketPurchaseServiceTest {
     void purchase_fail_insufficient_stock_but_complete_called() {
         // given
         given(queueOrchestrationService.isInProcessing(CONCERT_ID, USER_ID)).willReturn(true);
+        given(queueMetrics.getPurchaseDurationTimer()).willReturn(mock(Timer.class));
         willThrow(new InsufficientTicketStockException(0, QUANTITY))
                 .given(ticketStockService).decreaseByConcertId(CONCERT_ID, QUANTITY);
 
@@ -89,6 +97,7 @@ class TicketPurchaseServiceTest {
     void purchase_fail_unexpected_exception_but_complete_called() {
         // given
         given(queueOrchestrationService.isInProcessing(CONCERT_ID, USER_ID)).willReturn(true);
+        given(queueMetrics.getPurchaseDurationTimer()).willReturn(mock(Timer.class));
         willThrow(new RuntimeException("예상치 못한 오류"))
                 .given(ticketStockService).decreaseByConcertId(CONCERT_ID, QUANTITY);
 


### PR DESCRIPTION
## Summary
- SSE 이벤트 전송을 비동기로 처리하기 위한 인프라 구성
- `AsyncConfig` 클래스 추가하여 SSE 전용 `ThreadPoolTaskExecutor` 빈 등록
- `SseEmitterService`에 비동기 전송 메서드 추가
  - `sendEventAsync()`: 비동기 이벤트 전송
  - `sendEventAndCompleteAsync()`: 비동기 이벤트 전송 후 연결 종료
  - `broadcastPositionsAsync()`: 모든 대기자에게 순번 정보 병렬 전송
- 스레드풀 설정값을 `application.yml`에서 관리하도록 구성

### 스레드풀 기본 설정
| 설정 | 값 | 설명 |
|------|---|------|
| core-size | 10 | 기본 스레드 수 |
| max-size | 50 | 최대 스레드 수 |
| queue-capacity | 100 | 대기 큐 크기 |

### 변경 파일
- `AsyncConfig.java`
- `SseEmitterService.java`
- `application.yml`
- `SseEmitterServiceTest.java`